### PR TITLE
Introduce `liq_cue_skip` and fix bugs

### DIFF
--- a/cue_file
+++ b/cue_file
@@ -70,9 +70,9 @@
 #                         possibly deliver outdated metadata to us.
 # 2024-08-05 Moonbase59 - v4.1.1 Fix JSON overriding if `liq_cue_file` is true
 # 2024-08-12 t0mtaylor  - v4.2.0 Introduce `skip` arg and `liq_cue_skip` tag for files 
-                          to avoid reprocessing by force, and fix Mutagen m4a python
-                          TypeError: encoding without a string argument on Mac when
-                          writing tags for m4a/mp4 files.
+#                         to avoid reprocessing by force, and fix Mutagen m4a python
+#                         TypeError: encoding without a string argument on Mac when
+#                         writing tags for m4a/mp4 files.
 #
 # Originally based on an idea and some code by John Warburton (@Warblefly):
 #   https://github.com/Warblefly/TrackBoundaries
@@ -871,7 +871,7 @@ def analyse(
     })
 
 
-def write_tags(filename, tags={}, replaygain=False, skip=False):
+def write_tags(filename, tags={}, replaygain=False, writeSkipTag=False):
     # Add the liq_* tags (and only these)
     # Only touch replaygain_track_gain or R128_TRACK_GAIN if so requested.
     # Only write tags to files if we can safely do so.
@@ -920,7 +920,7 @@ def write_tags(filename, tags={}, replaygain=False, skip=False):
         tags_new["replaygain_reference_loudness"] += " LUFS"
         
         
-        if skip:
+        if writeSkipTag:
             tags_new["liq_cue_skip"] = True
         
 
@@ -1264,11 +1264,21 @@ if args.debug:
     
 if not "liq_cue_skip" in tags_found:
     NO_SKIP_TAGS = True
+    
+if args.debug:
+    print('Before args.skip: ' + str(args.skip) + ' | skip_analysis: ' + str(skip_analysis) + ' - if true because no tag change')
 
-if args.skip and "liq_cue_skip" in tags_found and tags_found["liq_cue_skip"] == True:
+if args.skip:
+    if "liq_cue_skip" in tags_found and tags_found["liq_cue_skip"] == True:
+        skip_analysis = True
+
+if "liq_cue_file" in tags_found and tags_found["liq_cue_file"] == True:
     skip_analysis = True
-if args.skip and "liq_cue_file" in tags_found and tags_found["liq_cue_file"] == True:
-    skip_analysis = True
+
+if args.debug and args.skip:
+    print('args.skip is enabled: ' + str(args.skip))
+if args.debug:
+    print('After args.skip: ' + str(args.skip) + ' | skip_analysis: ' + str(skip_analysis))
 
 if args.force and skip_analysis != True:
     result = analyse(
@@ -1298,7 +1308,7 @@ else:
 if args.write and NO_SKIP_TAGS: #and not args.skip
     if args.debug:
         print('START: writing autocue tags for '+args.file)
-    write_tags(args.file, result, args.replaygain, NO_SKIP_TAGS)
+    write_tags(args.file, result, args.replaygain, NO_SKIP_TAGS) #args.skip
     if args.debug:
         print('FINISHED: autocue tags written for '+args.file)
 

--- a/cue_file
+++ b/cue_file
@@ -69,13 +69,17 @@
 #                         forbid external processes to call us again and
 #                         possibly deliver outdated metadata to us.
 # 2024-08-05 Moonbase59 - v4.1.1 Fix JSON overriding if `liq_cue_file` is true
+# 2024-08-12 t0mtaylor  - v4.2.0 Introduce `skip` arg and `liq_cue_skip` tag for files 
+                          to avoid reprocessing by force, and fix Mutagen m4a python
+                          TypeError: encoding without a string argument on Mac when
+                          writing tags for m4a/mp4 files.
 #
 # Originally based on an idea and some code by John Warburton (@Warblefly):
 #   https://github.com/Warblefly/TrackBoundaries
 # Some collaborative work with RM-FM (@RM-FM): Sustained ending analysis.
 
 __author__ = 'Matthias C. Hormann'
-__version__ = '4.1.1'
+__version__ = '4.2.0'
 
 import os
 import sys
@@ -126,6 +130,8 @@ LONGTAIL_EXTRA_LU = -12.0  # reduce 15 dB extra on long tail songs to find overl
 SUSTAINED_LOUDNESS_DROP = 40.0  # max. percent drop to be considered sustained
 BLANKSKIP = 5.0  # min. seconds silence to detect blank
 NICE = False  # use Linux/MacOS nice?
+SKIP = False  # force skip reprocessing of file if tags already exist
+NO_SKIP_TAGS = False # allow new tags to be writen to file (when write enabled) unless skip tag exists and skip arg is set
 
 # These file types can be handled correctly by ffmpeg
 safe_ext = [
@@ -219,6 +225,7 @@ tags_to_check = {
     "liq_cross_start_next": float,
     "liq_cue_duration": float,
     "liq_cue_file": is_true,
+    "liq_cue_skip": is_true,
     "liq_cue_in": float,
     "liq_cue_out": float,
     "liq_fade_in": float,
@@ -308,12 +315,14 @@ def override_from_JSON(tags, tags_json={}):
     # do NOT overwrite from JSON if `liq_cue_file` is true
     if "liq_cue_file" in tags and tags["liq_cue_file"] == True:
         pass
+    # do NOT overwrite from JSON if `liq_cue_skip` is true
+    elif "liq_cue_skip" in tags and tags["liq_cue_skip"] == True:
+        pass
     else:
         # unify, right overwrites left if key in both
         tags = {**tags, **tags_in_json}
 
     return tags
-
 
 def read_tags(
         filename,
@@ -420,6 +429,7 @@ def read_tags(
         tags_found["liq_amplify"] += (target -
                                       tags_found["liq_reference_loudness"])
         tags_found["liq_reference_loudness"] = target
+        
     else:
         # liq_amplify or liq_reference_loudness missing, must re-analyse
         skip_analysis = False
@@ -468,6 +478,17 @@ def add_missing(tags_found, target=TARGET_LUFS, blankskip=0.0, noclip=False):
 
     if "liq_sustained_ending" not in tags_found:
         tags_found["liq_sustained_ending"] = False
+
+    if not "liq_cue_file" in tags_found:
+        tags_found["liq_cue_file"] = False
+
+    if not "liq_cue_skip" in tags_found:
+        tags_found["liq_cue_skip"] = False
+
+    if args.skip:
+        tags_found["liq_cue_file"] = True
+        tags_found["liq_cue_skip"] = True
+        tags_found["liq_blankskip"] = 0.0
 
     # if not "liq_cross_duration" in tags_found:
     #    tags_found["liq_cross_duration"] = tags_found["liq_cue_out"] - tags_found["liq_cross_start_next"]
@@ -850,7 +871,7 @@ def analyse(
     })
 
 
-def write_tags(filename, tags={}, replaygain=False):
+def write_tags(filename, tags={}, replaygain=False, skip=False):
     # Add the liq_* tags (and only these)
     # Only touch replaygain_track_gain or R128_TRACK_GAIN if so requested.
     # Only write tags to files if we can safely do so.
@@ -897,6 +918,11 @@ def write_tags(filename, tags={}, replaygain=False):
         tags_new["replaygain_track_gain"] += " dB"
         tags_new["replaygain_track_range"] += " dB"
         tags_new["replaygain_reference_loudness"] += " LUFS"
+        
+        
+        if skip:
+            tags_new["liq_cue_skip"] = True
+        
 
         if replaygain:
             # delete unwanted tags
@@ -1192,9 +1218,21 @@ parser.add_argument(
     default=False,
     action='store_true')
 parser.add_argument(
+    "-p",
+    "--skip",
+    help="Force Skip of re-analysis and skip write if tags exist, overrides --force option",
+    default=False,
+    action='store_true')
+parser.add_argument(
     "-n",
     "--nice",
     help="Linux/MacOS only: Use nice? Will run analysis at nice level 18.",
+    default=False,
+    action='store_true')
+parser.add_argument(
+    "-z",
+    "--debug",
+    help="Debug mode with addtional messages",
     default=False,
     action='store_true')
 parser.add_argument(
@@ -1221,7 +1259,18 @@ if args.json:
 skip_analysis, tags_found = read_tags(
     args.file, tags_json, args.target, args.blankskip, args.noclip)
 
-if args.force or not skip_analysis:
+if args.debug:
+    print(tags_found)
+    
+if not "liq_cue_skip" in tags_found:
+    NO_SKIP_TAGS = True
+
+if args.skip and "liq_cue_skip" in tags_found and tags_found["liq_cue_skip"] == True:
+    skip_analysis = True
+if args.skip and "liq_cue_file" in tags_found and tags_found["liq_cue_file"] == True:
+    skip_analysis = True
+
+if args.force and skip_analysis != True:
     result = analyse(
         filename=args.file,
         target=args.target,
@@ -1240,13 +1289,18 @@ if args.force or not skip_analysis:
     # override duration, seems ffprobe can be more exact
     if "duration" in tags_found:
         result["duration"] = tags_found["duration"]
+
 else:
     result = add_missing(tags_found, args.target, args.blankskip, args.noclip)
 
 # eprint(result)
 
-if args.write:
-    write_tags(args.file, result, args.replaygain)
+if args.write and NO_SKIP_TAGS: #and not args.skip
+    if args.debug:
+        print('START: writing autocue tags for '+args.file)
+    write_tags(args.file, result, args.replaygain, NO_SKIP_TAGS)
+    if args.debug:
+        print('FINISHED: autocue tags written for '+args.file)
 
 # prepare JSON result
 # we use "dB" instead of "LU" units, because LS & others don’t understand "LU"

--- a/cue_file
+++ b/cue_file
@@ -916,7 +916,7 @@ def write_tags(filename, tags={}, replaygain=False, writeSkipTag=False):
 
         if writeSkipTag:
             tags_new["liq_cue_skip"] = True
-            tags_new["liq_cue_file"] = False
+            tags_new["liq_cue_file"] = True
             tags_new["liq_blankskip"] = 0.0
 
         if replaygain:

--- a/cue_file
+++ b/cue_file
@@ -951,7 +951,7 @@ def write_tags(filename, tags={}, replaygain=False, skip=False):
             if f.tags is None:
                 f.add_tags()
             for k, v in tags_new.items():
-                f[f'----:com.apple.iTunes:{k}'] = bytes(v, 'utf-8')
+                f[f'----:com.apple.iTunes:{k}'] = bytes(str(v), 'utf-8')
             f.save()
 
         elif MUTAGEN_AVAILABLE and filename.suffix.casefold() in id3_ext:

--- a/cue_file
+++ b/cue_file
@@ -131,7 +131,7 @@ SUSTAINED_LOUDNESS_DROP = 40.0  # max. percent drop to be considered sustained
 BLANKSKIP = 5.0  # min. seconds silence to detect blank
 NICE = False  # use Linux/MacOS nice?
 SKIP = False  # force skip reprocessing of file if tags already exist
-NO_SKIP_TAGS = False # allow new tags to be writen to file (when write enabled) unless skip tag exists and skip arg is set
+NO_SKIP_TAGS = False  # allow new tags to be writen to file (when write enabled) unless skip tag exists and skip arg is set
 
 # These file types can be handled correctly by ffmpeg
 safe_ext = [
@@ -480,15 +480,10 @@ def add_missing(tags_found, target=TARGET_LUFS, blankskip=0.0, noclip=False):
         tags_found["liq_sustained_ending"] = False
 
     if not "liq_cue_file" in tags_found:
-        tags_found["liq_cue_file"] = False
+        tags_found["liq_cue_file"] = True
 
     if not "liq_cue_skip" in tags_found:
         tags_found["liq_cue_skip"] = False
-
-    if args.skip:
-        tags_found["liq_cue_file"] = True
-        tags_found["liq_cue_skip"] = True
-        tags_found["liq_blankskip"] = 0.0
 
     # if not "liq_cross_duration" in tags_found:
     #    tags_found["liq_cross_duration"] = tags_found["liq_cue_out"] - tags_found["liq_cross_start_next"]
@@ -918,11 +913,11 @@ def write_tags(filename, tags={}, replaygain=False, writeSkipTag=False):
         tags_new["replaygain_track_gain"] += " dB"
         tags_new["replaygain_track_range"] += " dB"
         tags_new["replaygain_reference_loudness"] += " LUFS"
-        
-        
+
         if writeSkipTag:
             tags_new["liq_cue_skip"] = True
-        
+            tags_new["liq_cue_file"] = False
+            tags_new["liq_blankskip"] = 0.0
 
         if replaygain:
             # delete unwanted tags
@@ -1280,7 +1275,7 @@ if args.debug and args.skip:
 if args.debug:
     print('After args.skip: ' + str(args.skip) + ' | skip_analysis: ' + str(skip_analysis))
 
-if args.force and skip_analysis != True:
+if args.force or skip_analysis != True:
     result = analyse(
         filename=args.file,
         target=args.target,
@@ -1305,7 +1300,10 @@ else:
 
 # eprint(result)
 
-if args.write and NO_SKIP_TAGS: #and not args.skip
+if not args.skip:
+    NO_SKIP_TAGS = True
+
+if args.write and NO_SKIP_TAGS:
     if args.debug:
         print('START: writing autocue tags for '+args.file)
     write_tags(args.file, result, args.replaygain, NO_SKIP_TAGS) #args.skip


### PR DESCRIPTION
proposed v4.2.0 with new options:

Reason for change: To allow rerun of `cue_file` within a script over files sync'd and so it wont reprocess files that have already been processed and tagged

The added benefit of the `liq_cue_skip` tag also now stops the file metadata/tags being written again to the media file, which would cause the modified date to change when it doesn't need to. This causes a nightmare for bi-direction sync.

- Introduce `skip` arg and `liq_cue_skip` tag for files to avoid reprocessing by force, as current logic doesn't seem to work as expected, this is backwards compatible with previously processed files and not a breaking change. Files may require reprocessing `one time` to add the new tag where required. 

- The `liq_cue_file` must be **true** when skip is enabled, to allow Azuracast to read the tags and avoid any more re-processing, - although when true Azuracast outputs:`cue_file results override existing metadata because liq_cue_file=true tells us to.` which means Azuracast may need to support the skip tag to be forced to just read the tags when this is true.

- fix Mutagen m4a python TypeError: encoding without a string argument on Mac when writing tags for m4a/mp4 files (should be string).

- Add debug flag to allow some additional messages when required

example command line, which includes `write, replygain, skip (-p), debug (-z)`:

`./cue_file "filename.mp3" -wrpz`

force will still work if required, or you remove skip for existing checks